### PR TITLE
Use MONOTONIC CLOCK instead of REALTIME CLOCK

### DIFF
--- a/netsim-async/src/lib.rs
+++ b/netsim-async/src/lib.rs
@@ -1,6 +1,8 @@
 mod sim_context;
 mod sim_link;
 
+use std::time::SystemTime;
+
 pub use self::sim_context::SimContext;
 pub(crate) use self::sim_link::{link, SimDownLink, SimUpLink};
 use anyhow::Result;
@@ -59,7 +61,7 @@ where
     T: HasBytesSize,
 {
     pub fn send_to(&self, to: SimId, msg: T) -> Result<()> {
-        let msg = Msg::new(self.id(), to, msg);
+        let msg = Msg::new(self.id(), to, SystemTime::now(), msg);
         self.up.send_msg(msg)
     }
 
@@ -81,7 +83,7 @@ where
     T: HasBytesSize,
 {
     pub fn send_to(&self, to: SimId, msg: T) -> Result<()> {
-        let msg = Msg::new(self.id, to, msg);
+        let msg = Msg::new(self.id, to, SystemTime::now(), msg);
         self.up.send_msg(msg)
     }
 }

--- a/netsim-async/src/lib.rs
+++ b/netsim-async/src/lib.rs
@@ -1,8 +1,6 @@
 mod sim_context;
 mod sim_link;
 
-use std::time::SystemTime;
-
 pub use self::sim_context::SimContext;
 pub(crate) use self::sim_link::{link, SimDownLink, SimUpLink};
 use anyhow::Result;
@@ -70,7 +68,7 @@ where
     T: HasBytesSize,
 {
     pub fn send_to(&self, to: SimId, msg: T) -> Result<()> {
-        let msg = Msg::new(self.id, to, SystemTime::now(), msg);
+        let msg = Msg::new(self.id, to, msg);
         self.up.send_msg(msg)
     }
 }

--- a/netsim-core/src/msg.rs
+++ b/netsim-core/src/msg.rs
@@ -1,5 +1,5 @@
 use crate::SimId;
-use std::time::SystemTime;
+use std::time::Instant;
 
 /// Trait for message content that will be sent via
 /// [`send_to`] and [`recv`] function of the [`SimSocket`].
@@ -19,21 +19,21 @@ pub trait HasBytesSize: Send + 'static {
 pub struct Msg<T> {
     from: SimId,
     to: SimId,
-    time: SystemTime,
+    time: Instant,
     content: T,
 }
 
 pub struct MsgWith<T> {
     pub msg: Msg<T>,
-    pub reception_time: SystemTime,
+    pub reception_time: Instant,
 }
 
 impl<T> Msg<T> {
-    pub fn new(from: SimId, to: SimId, time: SystemTime, content: T) -> Self {
+    pub fn new(from: SimId, to: SimId, content: T) -> Self {
         Self {
             from,
             to,
-            time,
+            time: Instant::now(),
             content,
         }
     }
@@ -46,7 +46,7 @@ impl<T> Msg<T> {
         self.to
     }
 
-    pub fn time(&self) -> SystemTime {
+    pub fn time(&self) -> Instant {
         self.time
     }
 

--- a/netsim-core/src/msg.rs
+++ b/netsim-core/src/msg.rs
@@ -29,11 +29,11 @@ pub struct MsgWith<T> {
 }
 
 impl<T> Msg<T> {
-    pub fn new(from: SimId, to: SimId, content: T) -> Self {
+    pub fn new(from: SimId, to: SimId, time: SystemTime, content: T) -> Self {
         Self {
             from,
             to,
-            time: SystemTime::now(),
+            time,
             content,
         }
     }

--- a/netsim-core/src/sim_context.rs
+++ b/netsim-core/src/sim_context.rs
@@ -235,7 +235,12 @@ where
                     on_drop.handle(msg.into_content())
                 }
             }
-            PolicyOutcome::Delay { until } => self.msgs.push(until, msg),
+            PolicyOutcome::Delay { delay } => {
+                // TODO: time acceleration may happen here
+                let until = msg.time() + delay;
+
+                self.msgs.push(until, msg)
+            }
         }
 
         Ok(())
@@ -246,8 +251,8 @@ where
     /// these are the messages that are due to be sent.
     /// This function may returns an empty `Vec` and this
     /// simply means there are no messages to be forwarded
-    pub fn outbound_messages(&mut self) -> Result<Vec<Msg<UpLink::Msg>>> {
-        Ok(self.msgs.pop_all_elapsed(SystemTime::now()))
+    pub fn outbound_messages(&mut self, time: SystemTime) -> Result<Vec<Msg<UpLink::Msg>>> {
+        Ok(self.msgs.pop_all_elapsed(time))
     }
 
     /// get the earliest time to the next message
@@ -258,8 +263,8 @@ where
         self.msgs.time_to_next_msg()
     }
 
-    fn propagate_msgs(&mut self) -> Result<()> {
-        for msg in self.outbound_messages()? {
+    fn propagate_msgs(&mut self, time: SystemTime) -> Result<()> {
+        for msg in self.outbound_messages(time)? {
             self.propagate_msg(msg)?;
         }
 
@@ -287,7 +292,7 @@ where
         Ok(())
     }
 
-    fn step(&mut self) -> Result<MuxOutcome> {
+    fn step(&mut self, time: SystemTime) -> Result<MuxOutcome> {
         while let Some(bus_message) = self.bus.try_receive() {
             match bus_message {
                 BusMessage::Disconnected | BusMessage::Shutdown => {
@@ -297,17 +302,17 @@ where
             }
         }
 
-        self.propagate_msgs()?;
+        self.propagate_msgs(time)?;
 
         Ok(MuxOutcome::Continue)
     }
 
-    pub(crate) fn sleep_time(&mut self) -> Duration {
+    pub(crate) fn sleep_time(&mut self, current_time: SystemTime) -> Duration {
         let Some(time) = self.earliest_outbound_time() else {
             return self.idle_duration;
         };
 
-        SystemTime::now()
+        current_time
             .duration_since(time)
             .unwrap_or(self.idle_duration)
     }
@@ -320,12 +325,14 @@ enum MuxOutcome {
 
 fn run_mux<UpLink: Link>(mut mux: SimMuxCore<UpLink>) -> Result<()> {
     loop {
-        match mux.step()? {
+        let time = SystemTime::now();
+
+        match mux.step(time)? {
             MuxOutcome::Continue => (),
             MuxOutcome::Shutdown => break,
         }
 
-        thread::sleep(mux.sleep_time());
+        thread::sleep(mux.sleep_time(time));
     }
 
     Ok(())

--- a/netsim-core/src/time_queue.rs
+++ b/netsim-core/src/time_queue.rs
@@ -126,7 +126,10 @@ mod tests {
         let entry_due_time = entry_sent_time + DURATION;
         let current_time = SystemTime::now() + 2 * DURATION;
 
-        c.push(entry_due_time, Msg::new(SIM_ID, SIM_ID, ()));
+        c.push(
+            entry_due_time,
+            Msg::new(SIM_ID, SIM_ID, entry_sent_time, ()),
+        );
 
         assert!(!c.is_empty());
         assert_eq!(c.len(), 1);

--- a/netsim-core/src/time_queue.rs
+++ b/netsim-core/src/time_queue.rs
@@ -1,7 +1,7 @@
 use crate::msg::MsgWith;
 use crate::Msg;
 use core::cmp::Reverse;
-use std::{collections::BinaryHeap, time::SystemTime};
+use std::{collections::BinaryHeap, time::Instant};
 
 pub struct TimeQueue<T> {
     map: BinaryHeap<Reverse<OrderedByTime<T>>>,
@@ -57,7 +57,7 @@ impl<T> TimeQueue<T> {
     }
 
     #[inline]
-    pub fn time_to_next_msg(&self) -> Option<SystemTime> {
+    pub fn time_to_next_msg(&self) -> Option<Instant> {
         self.map.peek().map(|v| v.0.inner().reception_time)
     }
 
@@ -65,7 +65,7 @@ impl<T> TimeQueue<T> {
         self.map.pop().map(|v| v.0.into_inner().msg)
     }
 
-    pub fn pop_all_elapsed(&mut self, time: SystemTime) -> Vec<Msg<T>> {
+    pub fn pop_all_elapsed(&mut self, time: Instant) -> Vec<Msg<T>> {
         let mut msgs = Vec::new();
         loop {
             match self.map.peek() {
@@ -85,7 +85,7 @@ impl<T> TimeQueue<T> {
         msgs
     }
 
-    pub fn push(&mut self, time: SystemTime, msg: Msg<T>) {
+    pub fn push(&mut self, time: Instant, msg: Msg<T>) {
         let m = MsgWith {
             reception_time: time,
             msg,
@@ -104,7 +104,7 @@ impl<T> Default for TimeQueue<T> {
 mod tests {
     use super::*;
     use crate::SimId;
-    use std::time::{Duration, SystemTime};
+    use std::time::Duration;
 
     #[test]
     fn empty() {
@@ -122,14 +122,11 @@ mod tests {
     #[test]
     fn entry() {
         let mut c = TimeQueue::<()>::new();
-        let entry_sent_time = SystemTime::now();
+        let entry_sent_time = Instant::now();
         let entry_due_time = entry_sent_time + DURATION;
-        let current_time = SystemTime::now() + 2 * DURATION;
+        let current_time = Instant::now() + 2 * DURATION;
 
-        c.push(
-            entry_due_time,
-            Msg::new(SIM_ID, SIM_ID, entry_sent_time, ()),
-        );
+        c.push(entry_due_time, Msg::new(SIM_ID, SIM_ID, ()));
 
         assert!(!c.is_empty());
         assert_eq!(c.len(), 1);

--- a/netsim/src/sim_socket.rs
+++ b/netsim/src/sim_socket.rs
@@ -1,7 +1,7 @@
 use crate::{sim_link::SimDownLink, HasBytesSize, SimId};
 use anyhow::Result;
 use netsim_core::{BusSender, Msg};
-use std::sync::mpsc;
+use std::{sync::mpsc, time::SystemTime};
 
 pub struct SimSocket<T> {
     reader: SimSocketReadHalf<T>,
@@ -85,7 +85,7 @@ where
     T: HasBytesSize,
 {
     pub fn send_to(&self, to: SimId, msg: T) -> Result<()> {
-        let msg = Msg::new(self.id, to, msg);
+        let msg = Msg::new(self.id, to, SystemTime::now(), msg);
         self.up.send_msg(msg)
     }
 }

--- a/netsim/src/sim_socket.rs
+++ b/netsim/src/sim_socket.rs
@@ -1,7 +1,7 @@
 use crate::{sim_link::SimDownLink, HasBytesSize, SimId};
 use anyhow::Result;
 use netsim_core::{BusSender, Msg};
-use std::{sync::mpsc, time::SystemTime};
+use std::sync::mpsc;
 
 pub struct SimSocket<T> {
     reader: SimSocketReadHalf<T>,
@@ -85,7 +85,7 @@ where
     T: HasBytesSize,
 {
     pub fn send_to(&self, to: SimId, msg: T) -> Result<()> {
-        let msg = Msg::new(self.id, to, SystemTime::now(), msg);
+        let msg = Msg::new(self.id, to, msg);
         self.up.send_msg(msg)
     }
 }


### PR DESCRIPTION
the changes allows us to move to improved performances in overhead, running the following:

```
sh$ cargo run --example flood --release -- --time 10s --every 2ms --idle 10us

```

Will display the following output (or something similar) on Apple M2:

```
sent 9000 messages over. Msg received with an average of 5.189µs delays to the expected LATENCY
...
```