### PR TITLE
Improve the Simulator performances with array-based storage

### DIFF
--- a/netsim-core/src/congestion_queue.rs
+++ b/netsim-core/src/congestion_queue.rs
@@ -160,7 +160,7 @@ where
             .entry(envelop.msg.from())
             .and_modify(|u| u.refresh(time))
             .or_insert_with(|| Usage::new(time));
-        let s_policy = nodes[envelop.msg.from().0 as usize]
+        let s_policy = nodes[envelop.msg.from().into_index()]
             .policy()
             .unwrap_or_else(|| policy.default_node_policy());
         let remaining_size = message_size - envelop.sender;
@@ -189,7 +189,7 @@ where
             .entry(envelop.msg.to())
             .and_modify(|u| u.refresh(time))
             .or_insert_with(|| Usage::new(time));
-        let r_policy = nodes[envelop.msg.to().0 as usize]
+        let r_policy = nodes[envelop.msg.to().into_index()]
             .policy()
             .unwrap_or_else(|| policy.default_node_policy());
         let remaining_size = envelop.link - envelop.receiver;

--- a/netsim-core/src/congestion_queue.rs
+++ b/netsim-core/src/congestion_queue.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{Bandwidth, Edge, HasBytesSize, Msg, Policy, SimId};
+use crate::{sim_context::SimLinks, Bandwidth, Edge, HasBytesSize, Msg, Policy, SimId};
 
 /// used to keep track of how much of a packet has been sent through
 /// one of the network components (sender, link and receiver).
@@ -138,7 +138,13 @@ where
         self.queue.push_back(envelop)
     }
 
-    fn pop(&mut self, time: Instant, policy: &Policy, index: usize) -> Option<Msg<T>> {
+    fn pop<UpLink>(
+        &mut self,
+        time: Instant,
+        nodes: &SimLinks<UpLink>,
+        policy: &Policy,
+        index: usize,
+    ) -> Option<Msg<T>> {
         let envelop = self.queue.get_mut(index)?;
         if envelop.latency > time {
             // we ignore messages that are still meant to be delayed
@@ -154,8 +160,8 @@ where
             .entry(envelop.msg.from())
             .and_modify(|u| u.refresh(time))
             .or_insert_with(|| Usage::new(time));
-        let s_policy = policy
-            .get_node_policy(envelop.msg.from())
+        let s_policy = nodes[envelop.msg.from().0 as usize]
+            .policy()
             .unwrap_or_else(|| policy.default_node_policy());
         let remaining_size = message_size - envelop.sender;
         let used = s
@@ -183,8 +189,8 @@ where
             .entry(envelop.msg.to())
             .and_modify(|u| u.refresh(time))
             .or_insert_with(|| Usage::new(time));
-        let r_policy = policy
-            .get_node_policy(envelop.msg.to())
+        let r_policy = nodes[envelop.msg.to().0 as usize]
+            .policy()
             .unwrap_or_else(|| policy.default_node_policy());
         let remaining_size = envelop.link - envelop.receiver;
         let used = r
@@ -205,7 +211,12 @@ where
         }
     }
 
-    pub fn pop_many(&mut self, time: Instant, policy: &Policy) -> Vec<Msg<T>> {
+    pub fn pop_many<UpLink>(
+        &mut self,
+        time: Instant,
+        nodes: &SimLinks<UpLink>,
+        policy: &Policy,
+    ) -> Vec<Msg<T>> {
         let mut msgs = Vec::new();
 
         let mut index = 0usize;
@@ -216,7 +227,7 @@ where
         // which means that when we remove an entry we won't increase the `index`
         // but the size is still reduced because the queue has an entry less
         while index < self.queue.len() {
-            if let Some(entry) = self.pop(time, policy, index) {
+            if let Some(entry) = self.pop(time, nodes, policy, index) {
                 msgs.push(entry);
             } else {
                 index += 1;
@@ -237,7 +248,7 @@ impl<T: HasBytesSize> Default for CongestionQueue<T> {
 mod tests {
     use std::str::FromStr;
 
-    use crate::{EdgePolicy, Latency, NodePolicy, PacketLoss};
+    use crate::{sim_context::SimLink, EdgePolicy, Latency, NodePolicy, PacketLoss};
 
     use super::*;
 
@@ -281,12 +292,12 @@ mod tests {
         }
     }
 
-    const ALICE: SimId = SimId::new(1);
-    const BOB: SimId = SimId::new(2);
+    const ALICE: SimId = SimId::new(0);
+    const BOB: SimId = SimId::new(1);
 
     macro_rules! test_pop_message {
-        ($cq:ident, $policy:ident, t: $time:expr, $sender:ident : $s:expr, $link:ident: $l:expr, $receiver:ident : $r:expr $(,)?) => {
-            assert!($cq.pop($time, &$policy, 0).is_none());
+        ($cq:ident, $nodes:ident, $policy:ident, t: $time:expr, $sender:ident : $s:expr, $link:ident: $l:expr, $receiver:ident : $r:expr $(,)?) => {
+            assert!($cq.pop($time, &$nodes, &$policy, 0).is_none());
             let sender = $cq.nodes_usage.get(&$sender).unwrap();
             assert_eq!(
                 sender.upload.counter,
@@ -323,6 +334,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::vec_init_then_push)]
     fn congestion_queue_pop() {
         #[allow(non_snake_case)]
         let ALICE_BOB: Edge = Edge::new((ALICE, BOB));
@@ -340,6 +352,10 @@ mod tests {
             packet_loss: PacketLoss::NONE,
         });
 
+        let mut nodes = SimLinks::<()>::new();
+        nodes.push(SimLink::new(()));
+        nodes.push(SimLink::new(()));
+
         let mut cq = CongestionQueue::<Event>::new();
 
         let time = Instant::now();
@@ -348,7 +364,7 @@ mod tests {
         // First we will need to do 10 iterations to clear alice's buffer
         for i in 0..10 {
             test_pop_message!(
-                cq, policy,
+                cq, nodes, policy,
                 t: time + Duration::from_secs(i),
                 ALICE: 100,
                 ALICE_BOB: 10,
@@ -361,7 +377,7 @@ mod tests {
         for i in 10..99 {
             // we expect the counter to be rest and fully used once more
             test_pop_message!(
-                cq, policy,
+                cq, nodes, policy,
                 t: time + Duration::from_secs(i),
                 ALICE: 0,
                 ALICE_BOB: 10,
@@ -370,6 +386,8 @@ mod tests {
         }
 
         // it should take 100 iteration to pop the message
-        assert!(cq.pop(time + Duration::from_secs(99), &policy, 0).is_some());
+        assert!(cq
+            .pop(time + Duration::from_secs(99), &nodes, &policy, 0)
+            .is_some());
     }
 }

--- a/netsim-core/src/policy.rs
+++ b/netsim-core/src/policy.rs
@@ -75,7 +75,6 @@ pub struct Policy {
     default_node_policy: NodePolicy,
     default_edge_policy: EdgePolicy,
 
-    node_policies: HashMap<SimId, NodePolicy>,
     edge_policies: HashMap<Edge, EdgePolicy>,
 }
 
@@ -193,18 +192,6 @@ impl Policy {
 
     pub fn set_default_edge_policy(&mut self, default_edge_policy: EdgePolicy) {
         self.default_edge_policy = default_edge_policy;
-    }
-
-    pub fn get_node_policy(&self, node: SimId) -> Option<NodePolicy> {
-        self.node_policies.get(&node).copied()
-    }
-
-    pub fn set_node_policy(&mut self, node: SimId, policy: NodePolicy) {
-        self.node_policies.insert(node, policy);
-    }
-
-    pub fn reset_node_policy(&mut self, node: SimId) {
-        self.node_policies.remove(&node);
     }
 
     pub fn get_edge_policy(&self, edge: Edge) -> Option<EdgePolicy> {

--- a/netsim-core/src/sim_context.rs
+++ b/netsim-core/src/sim_context.rs
@@ -83,7 +83,7 @@ where
     pub fn with_config(configuration: SimConfiguration<UpLink::Msg>) -> Self {
         let policy = Arc::new(RwLock::new(configuration.policy));
         let links = Arc::new(Mutex::new(HashMap::new()));
-        let next_sim_id = SimId::ZERO.next(); // Starts at 1
+        let next_sim_id = SimId::ZERO; // Starts at 0
 
         let (sender, receiver) = open_bus();
 

--- a/netsim-core/src/sim_context.rs
+++ b/netsim-core/src/sim_context.rs
@@ -154,7 +154,7 @@ where
             .links
             .lock()
             .unwrap()
-            .get_mut(node.0 as usize)
+            .get_mut(node.into_index())
             .map(|node| node.policy = Some(policy));
 
         debug_assert!(
@@ -171,7 +171,7 @@ where
             .links
             .lock()
             .unwrap()
-            .get_mut(node.0 as usize)
+            .get_mut(node.into_index())
             .map(|node| node.policy = None);
 
         debug_assert!(
@@ -196,7 +196,7 @@ where
 
         debug_assert_eq!(
             self.links.lock().unwrap().len(),
-            self.next_sim_id.0 as usize,
+            self.next_sim_id.into_index(),
             "The next available SimId is the lenght of the vec"
         );
 
@@ -305,7 +305,7 @@ where
             .lock()
             .map_err(|error| anyhow!("Failed to acquire address, mutex poisonned {error}"))?;
 
-        if let Some(sim_link) = addresses.get_mut(dst.0 as usize) {
+        if let Some(sim_link) = addresses.get_mut(dst.into_index()) {
             let _error = sim_link.link.send(msg);
             Ok(())
         } else {

--- a/netsim-core/src/sim_id.rs
+++ b/netsim-core/src/sim_id.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 /// The identifier of a peer in the SimNetwork
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
-pub struct SimId(u64);
+pub struct SimId(pub(crate) u64);
 
 impl SimId {
     pub(crate) const ZERO: Self = SimId::new(0);

--- a/netsim-core/src/sim_id.rs
+++ b/netsim-core/src/sim_id.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 /// The identifier of a peer in the SimNetwork
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
-pub struct SimId(pub(crate) u64);
+pub struct SimId(u64);
 
 impl SimId {
     pub(crate) const ZERO: Self = SimId::new(0);
@@ -17,6 +17,12 @@ impl SimId {
     #[must_use = "function does not modify the current value"]
     pub(crate) fn next(self) -> Self {
         Self::new(self.0 + 1)
+    }
+
+    /// we use the `SimId` as index of the array of links
+    #[inline(always)]
+    pub(crate) fn into_index(self) -> usize {
+        self.0 as usize
     }
 }
 


### PR DESCRIPTION
Here we change how we store the nodes policies and the UpLink. Instead of using a Hash Table we uses a Vec. It has simplified a few assumptions in many places and removed the unnecessary hash lookups.

A following change is to remove the mutexes in the SimContext and SimCore so that we don't have the necessary locks and improve even more performances (see #38).

closes #37