### PR TITLE
Improve performance of congestion_queue

### DIFF
--- a/netsim-core/src/congestion_queue.rs
+++ b/netsim-core/src/congestion_queue.rs
@@ -204,7 +204,7 @@ where
         debug_assert!(envelop.link >= envelop.receiver);
 
         if message_size == envelop.receiver {
-            let entry = self.queue.remove(index)?.msg;
+            let entry = self.queue.swap_remove_back(index)?.msg;
             Some(entry)
         } else {
             None


### PR DESCRIPTION
I ran a quick `cargo flamegraph` on the Leios simulation, and ~92% of CPU time was spent inside a call to `VecDeque::remove` from netsim. The order of elements in that `VecDeque` doesn't particularly matter, so replacing the O(n) `remove` with an O(1) `swap_remove_back` is a quick and easy performance win.  

This change is enough to get the Leios simulation running in realtime, which I think unblocks us from using the sim! However, when we try running the simulation faster than realtime, messages still seem to fall behind.